### PR TITLE
Added a String constructor 

### DIFF
--- a/assets/src/components/field/date/format.js
+++ b/assets/src/components/field/date/format.js
@@ -6,7 +6,7 @@ import { CalendarDate } from '@internationalized/date'
 const formatValue = (value, minDate) => {
   
   if( value instanceof CalendarDate) return value
-  const initialValue = (value ?? '').split('-')
+  const initialValue = String(value ?? '').split('-')
 
   return initialValue.length === 3
     ? new CalendarDate('AD', initialValue[0], initialValue[1], initialValue[2])


### PR DESCRIPTION
Added a `String` constructor wrapper for cases when value is a string literal and does not have a split method.