### PR TITLE
Enqueue wp_enqueue_media instead of calling it directly

### DIFF
--- a/fields/format.php
+++ b/fields/format.php
@@ -81,8 +81,7 @@ $fields->format_args = function(
       break;
 
     case 'gallery':
-      // Enqueue instead of calling directly
-      add_action('admin_enqueue_scripts', 'wp_enqueue_media');
+      $fields->enqueue_wp_media_uploader();
       break;
 
     case 'list':
@@ -104,8 +103,7 @@ $fields->format_args = function(
 
     case 'file':
       if( !isset( $args['wp_media'] ) || $args['wp_media'] ) {
-        // Enqueue instead of calling directly
-        add_action('admin_enqueue_scripts', 'wp_enqueue_media');
+        $fields->enqueue_wp_media_uploader();
       }
       $args = $fields->format_value($args, 'mime_types', 'mimeTypes');
       $args = $fields->format_value($args, 'max_upload', 'maxUpload');

--- a/fields/format.php
+++ b/fields/format.php
@@ -81,7 +81,8 @@ $fields->format_args = function(
       break;
 
     case 'gallery':
-      wp_enqueue_media();
+      // Enqueue instead of calling directly
+      add_action('admin_enqueue_scripts', 'wp_enqueue_media');
       break;
 
     case 'list':
@@ -102,7 +103,10 @@ $fields->format_args = function(
       break;
 
     case 'file':
-      if( !isset( $args['wp_media'] ) || $args['wp_media'] ) wp_enqueue_media();
+      if( !isset( $args['wp_media'] ) || $args['wp_media'] ) {
+        // Enqueue instead of calling directly
+        add_action('admin_enqueue_scripts', 'wp_enqueue_media');
+      }
       $args = $fields->format_value($args, 'mime_types', 'mimeTypes');
       $args = $fields->format_value($args, 'max_upload', 'maxUpload');
       break;

--- a/fields/index.php
+++ b/fields/index.php
@@ -6,6 +6,7 @@ $fields->registered_fields = [];
 
 require_once __DIR__ . '/conditional.php';
 require_once __DIR__ . '/format.php';
+require_once __DIR__ . '/media.php';
 require_once __DIR__ . '/store.php';
 
 /**

--- a/fields/media.php
+++ b/fields/media.php
@@ -1,0 +1,37 @@
+<?php
+
+defined('ABSPATH') or die();
+
+/**
+ * Enqueue WP media uploader
+ * 
+ * A wrapper around wp_enqueue_media() which needs to be enqueued at the
+ * right time to prevent issues like missing nonce for AJAX request.
+ */
+$fields->enqueue_wp_media_uploader = function() {
+
+  if (is_admin()) {
+
+    // Admin
+
+    // Before document head
+    $action = 'admin_enqueue_scripts';
+
+    if (doing_action($action) || did_action($action)) {
+      $action = 'admin_footer'; // During and after head
+    }
+
+  } else {
+
+    // Site frontend
+
+    // Before document head
+    $action = 'wp_enqueue_scripts';
+
+    if (doing_action($action) || did_action($action)) {
+      $action = 'wp_footer'; // During and after head
+    }
+  }
+
+  add_action($action, 'wp_enqueue_media');
+};

--- a/fields/media.php
+++ b/fields/media.php
@@ -18,7 +18,7 @@ $fields->enqueue_wp_media_uploader = function() {
     $action = 'admin_enqueue_scripts';
 
     if (doing_action($action) || did_action($action)) {
-      $action = 'admin_footer'; // During and after head
+      $action = 'admin_footer'; // During and after
     }
 
   } else {
@@ -29,7 +29,7 @@ $fields->enqueue_wp_media_uploader = function() {
     $action = 'wp_enqueue_scripts';
 
     if (doing_action($action) || did_action($action)) {
-      $action = 'wp_footer'; // During and after head
+      $action = 'wp_footer'; // During and after
     }
   }
 

--- a/fields/media.php
+++ b/fields/media.php
@@ -33,5 +33,5 @@ $fields->enqueue_wp_media_uploader = function() {
     }
   }
 
-  add_action($action, 'wp_enqueue_media');
+  add_action($action, 'wp_enqueue_media', 9); // enqueue before fields scripts
 };

--- a/tests/phpunit/cases/fields/format.php
+++ b/tests/phpunit/cases/fields/format.php
@@ -290,8 +290,13 @@ class FormatField_TestCase extends WP_UnitTestCase {
     ]);
 
     $this->assertFalse(
+      helpers\action_hook_has_callback('wp_enqueue_scripts', 'wp_enqueue_media'),
+      'wp_enqueue_media was enqueued using wp_enqueue_scripts'
+    );
+
+    $this->assertFalse(
       helpers\action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media'),
-      'wp_enqueue_media was enqueued'
+      'wp_enqueue_media was enqueued using admin_enqueue_scripts'
     );
 
     // With media uploader

--- a/tests/phpunit/cases/fields/format.php
+++ b/tests/phpunit/cases/fields/format.php
@@ -1,6 +1,6 @@
 <?php
 
-use function Tangible\Fields\Tests\action_hook_has_callback;
+use Tangible\Fields\Tests as helpers;
 
 // @todo: We need tests for the tab layout
 class FormatField_TestCase extends WP_UnitTestCase {
@@ -206,29 +206,169 @@ class FormatField_TestCase extends WP_UnitTestCase {
   }
 
   public function test_format_args_gallery_ensure_wp_enqueue_media() {
-    $args = tangible_fields()->format_args('test', [
-      'type' => 'gallery',
-    ]);
 
-    $is_enqueued = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
-    $this->assertTrue($is_enqueued, 'wp_enqueue_media was not enqueued');
+    $field_args = [
+      'type' => 'gallery',
+    ];
+
+    // Frontend before document head
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('wp_enqueue_scripts', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in site frontend before head'
+    );
+
+    // Frontend during head
+
+    helpers\mock_doing_action('wp_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('wp_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in site frontend during head'
+    );
+    helpers\unmock_doing_action('wp_enqueue_scripts');
+
+    // Frontend after head
+
+    helpers\mock_did_action('wp_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('wp_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in site frontend after head'
+    );
+      
+    helpers\unmock_did_action('wp_enqueue_scripts');
+
+    // Admin
+
+    // Admin before document head
+
+    helpers\mock_is_admin();
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in admin before head'
+    );
+
+    // Admin during head
+
+    helpers\mock_doing_action('admin_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('admin_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in admin during head'
+    );
+
+    helpers\unmock_doing_action('admin_enqueue_scripts');
+
+    // Admin after head
+
+    helpers\mock_did_action('admin_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('admin_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in admin after head'
+    );
+
+    helpers\unmock_did_action('admin_enqueue_scripts');
+
+    helpers\unmock_is_admin();
   }
 
   public function test_format_args_file_ensure_wp_enqueue_media() {
+
+    // Without media uploader
     $args = tangible_fields()->format_args('test', [
       'type'     => 'file',
       'wp_media' => false
     ]);
 
-    $is_enqueued = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
-    $this->assertFalse($is_enqueued, 'wp_enqueue_media was enqueued');
+    $this->assertFalse(
+      helpers\action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media'),
+      'wp_enqueue_media was enqueued'
+    );
 
-    $args = tangible_fields()->format_args('test', [
+    // With media uploader
+
+    $field_args = [
       'type' => 'file',
-    ]);
+    ];
 
-    $is_enqueued = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
-    $this->assertTrue($is_enqueued, 'wp_enqueue_media was not enqueued');
+    // Frontend before document head
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('wp_enqueue_scripts', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in site frontend before head'
+    );
+
+    // Frontend during head
+
+    helpers\mock_doing_action('wp_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('wp_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in site frontend during head'
+    );
+
+    helpers\unmock_doing_action('wp_enqueue_scripts');
+    
+    // Frontend after head
+
+    helpers\mock_did_action('wp_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('wp_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in site frontend after head'
+    );
+
+    helpers\unmock_did_action('wp_enqueue_scripts');
+
+    // Admin
+
+    // Admin before document head
+
+    helpers\mock_is_admin();
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in admin before head'
+    );
+
+    // Admin during head
+
+    helpers\mock_doing_action('admin_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('admin_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in admin during head'
+    );
+
+    helpers\unmock_doing_action('admin_enqueue_scripts');
+
+    // Admin after head
+
+    helpers\mock_did_action('admin_enqueue_scripts');
+
+    tangible_fields()->format_args('test', $field_args);
+    $this->assertTrue(
+      helpers\action_hook_has_callback('admin_footer', 'wp_enqueue_media'),
+      'wp_enqueue_media was not enqueued in admin after head'
+    );
+
+    helpers\unmock_did_action('admin_enqueue_scripts');
+
+    helpers\unmock_is_admin();
   }
 
   public function test_format_args_repeater_empty_value() {

--- a/tests/phpunit/cases/fields/format.php
+++ b/tests/phpunit/cases/fields/format.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Tangible\Fields\Tests\action_hook_has_callback;
+
 // @todo: We need tests for the tab layout
 class FormatField_TestCase extends WP_UnitTestCase {
 
@@ -207,7 +209,9 @@ class FormatField_TestCase extends WP_UnitTestCase {
     $args = tangible_fields()->format_args('test', [
       'type' => 'gallery',
     ]);
-    $this->assertGreaterThan(0, did_action('wp_enqueue_media'), 'wp_enqueue_media was not called');
+
+    $found_action = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
+    $this->assertTrue($found_action, 'wp_enqueue_media was not enqueued');
   }
 
   public function test_format_args_file_ensure_wp_enqueue_media() {
@@ -215,12 +219,16 @@ class FormatField_TestCase extends WP_UnitTestCase {
       'type'     => 'file',
       'wp_media' => false
     ]);
-    $this->assertEquals(0, did_action('wp_enqueue_media'), 'wp_enqueue_media was called');
+
+    $found_action = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
+    $this->assertFalse($found_action, 'wp_enqueue_media was enqueued');
 
     $args = tangible_fields()->format_args('test', [
       'type' => 'file',
     ]);
-    $this->assertGreaterThan(0, did_action('wp_enqueue_media'), 'wp_enqueue_media was not called');
+
+    $found_action = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
+    $this->assertTrue($found_action, 'wp_enqueue_media was not enqueued');
   }
 
   public function test_format_args_repeater_empty_value() {

--- a/tests/phpunit/cases/fields/format.php
+++ b/tests/phpunit/cases/fields/format.php
@@ -210,8 +210,8 @@ class FormatField_TestCase extends WP_UnitTestCase {
       'type' => 'gallery',
     ]);
 
-    $found_action = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
-    $this->assertTrue($found_action, 'wp_enqueue_media was not enqueued');
+    $is_enqueued = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
+    $this->assertTrue($is_enqueued, 'wp_enqueue_media was not enqueued');
   }
 
   public function test_format_args_file_ensure_wp_enqueue_media() {
@@ -220,15 +220,15 @@ class FormatField_TestCase extends WP_UnitTestCase {
       'wp_media' => false
     ]);
 
-    $found_action = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
-    $this->assertFalse($found_action, 'wp_enqueue_media was enqueued');
+    $is_enqueued = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
+    $this->assertFalse($is_enqueued, 'wp_enqueue_media was enqueued');
 
     $args = tangible_fields()->format_args('test', [
       'type' => 'file',
     ]);
 
-    $found_action = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
-    $this->assertTrue($found_action, 'wp_enqueue_media was not enqueued');
+    $is_enqueued = action_hook_has_callback('admin_enqueue_scripts', 'wp_enqueue_media');
+    $this->assertTrue($is_enqueued, 'wp_enqueue_media was not enqueued');
   }
 
   public function test_format_args_repeater_empty_value() {

--- a/tests/phpunit/helpers/action.php
+++ b/tests/phpunit/helpers/action.php
@@ -25,3 +25,45 @@ function action_hook_has_callback(
 
   return false;
 }
+
+/**
+ * Mock WP action hook is called already
+ * @see /wp-includes/plugin.php, did_action()
+ */
+function mock_did_action($hook_name, $count = 1) {
+	global $wp_actions;
+  if (isset($wp_actions[ $hook_name ])) {
+    $wp_actions[ $hook_name ] = $count;
+  }
+}
+
+/**
+ * Unmock did_action
+ */
+function unmock_did_action($hook_name) {
+	global $wp_actions;
+  $wp_actions[ $hook_name ] = 0;
+}
+
+/**
+ * Mock WP action hook is being called
+ * @see /wp-includes/plugin.php, doing_filter()
+ */
+function mock_doing_action($hook_name) {
+	global $wp_current_filter;
+
+  if ( ! in_array( $hook_name, $wp_current_filter, true ) ) {
+    $wp_current_filter []= $hook_name;
+  }
+}
+
+/**
+ * Unmock doing_action
+ */
+function unmock_doing_action($hook_name) {
+	global $wp_current_filter;
+
+  if (($key = array_search($hook_name, $wp_current_filter)) !== false) {
+    unset($wp_current_filter[ $key ]);
+  }
+}

--- a/tests/phpunit/helpers/action.php
+++ b/tests/phpunit/helpers/action.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tangible\Fields\Tests;
+
+/**
+ * Check if a callback was registered with a given WordPress action hook
+ * @see wp-includes/class-wp-hook.php, add_filter()
+ */
+function action_hook_has_callback(
+  string $action_name,
+  callable $callback
+): bool {
+  global $wp_filter;
+
+  $found_action = false;
+
+  if (isset($wp_filter['admin_enqueue_scripts'])) {
+    foreach ($wp_filter['admin_enqueue_scripts']->callbacks as $priority => $indexes) {
+      foreach ($indexes as $index => $definition) {
+        if ($definition['function']==='wp_enqueue_media') {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/tests/phpunit/helpers/action.php
+++ b/tests/phpunit/helpers/action.php
@@ -12,14 +12,12 @@ function action_hook_has_callback(
 ): bool {
   global $wp_filter;
 
-  $found_action = false;
+  if (!isset($wp_filter['admin_enqueue_scripts'])) return false;
 
-  if (isset($wp_filter['admin_enqueue_scripts'])) {
-    foreach ($wp_filter['admin_enqueue_scripts']->callbacks as $priority => $indexes) {
-      foreach ($indexes as $index => $definition) {
-        if ($definition['function']==='wp_enqueue_media') {
-          return true;
-        }
+  foreach ($wp_filter['admin_enqueue_scripts']->callbacks as $priority => $indexes) {
+    foreach ($indexes as $index => $definition) {
+      if ($definition['function']==='wp_enqueue_media') {
+        return true;
       }
     }
   }

--- a/tests/phpunit/helpers/action.php
+++ b/tests/phpunit/helpers/action.php
@@ -12,11 +12,11 @@ function action_hook_has_callback(
 ): bool {
   global $wp_filter;
 
-  if (!isset($wp_filter['admin_enqueue_scripts'])) return false;
+  if (!isset($wp_filter[ $action_name ])) return false;
 
-  foreach ($wp_filter['admin_enqueue_scripts']->callbacks as $priority => $indexes) {
+  foreach ($wp_filter[ $action_name ]->callbacks as $priority => $indexes) {
     foreach ($indexes as $index => $definition) {
-      if ($definition['function']==='wp_enqueue_media') {
+      if ($definition['function']===$callback) {
         return true;
       }
     }

--- a/tests/phpunit/helpers/action.php
+++ b/tests/phpunit/helpers/action.php
@@ -16,7 +16,7 @@ function action_hook_has_callback(
 
   foreach ($wp_filter[ $action_name ]->callbacks as $priority => $indexes) {
     foreach ($indexes as $index => $definition) {
-      if ($definition['function']===$callback) {
+      if ($definition['function'] === $callback) {
         return true;
       }
     }

--- a/tests/phpunit/helpers/action.php
+++ b/tests/phpunit/helpers/action.php
@@ -10,6 +10,7 @@ function action_hook_has_callback(
   string $action_name,
   callable $callback
 ): bool {
+
   global $wp_filter;
 
   if (!isset($wp_filter[ $action_name ])) return false;

--- a/tests/phpunit/helpers/admin.php
+++ b/tests/phpunit/helpers/admin.php
@@ -4,8 +4,11 @@ namespace Tangible\Fields\Tests;
 
 /**
  * Mock is_admin() to return true or false for testing purpose
- * 
- * It must be restored afterward with unmock_is_admin() below.
+ *
+ * Must call unmock_is_admin() afterward.
+ *
+ * @see wp-includes/load.php is_admin()
+ * @see wp-admin/includes/class-wp-screen.php WP_Screen::in_admin()
  */
 function mock_is_admin($state = true) {
 

--- a/tests/phpunit/helpers/admin.php
+++ b/tests/phpunit/helpers/admin.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tangible\Fields\Tests;
+
+/**
+ * Mock is_admin() to return true or false for testing purpose
+ * 
+ * It must be restored afterward with unmock_is_admin() below.
+ */
+function mock_is_admin($state = true) {
+
+  global $current_screen;
+
+  // Only once
+  if (!empty($current_screen) && property_exists($current_screen, 'original_screen')) {
+    return;
+  }
+
+  $screen = new class {
+    public $state;
+    public $original_screen;
+
+    function in_admin() {
+      return $this->state;
+    }
+  };
+
+  $screen->state = $state;
+  $screen->original_screen = $current_screen;
+
+  $current_screen = $screen;
+}
+
+/**
+ * Restore original screen and free the mock screen object
+ */
+function unmock_is_admin() {
+
+  global $current_screen;
+
+  if (!property_exists($current_screen, 'original_screen')) {
+    return;
+  }
+
+  $current_screen = $current_screen->original_screen;
+}

--- a/tests/phpunit/helpers/index.php
+++ b/tests/phpunit/helpers/index.php
@@ -1,5 +1,6 @@
 <?php
 
-require_once __DIR__ . '/render.php';
-require_once __DIR__ . '/date.php';
 require_once __DIR__ . '/action.php';
+require_once __DIR__ . '/admin.php';
+require_once __DIR__ . '/date.php';
+require_once __DIR__ . '/render.php';

--- a/tests/phpunit/helpers/index.php
+++ b/tests/phpunit/helpers/index.php
@@ -2,3 +2,4 @@
 
 require_once __DIR__ . '/render.php';
 require_once __DIR__ . '/date.php';
+require_once __DIR__ . '/action.php';


### PR DESCRIPTION
- It should be called from the `admin_enqueue_scripts` action hook or later
  - See https://developer.wordpress.org/reference/functions/wp_enqueue_media/#user-contributed-notes
- Resolves TangibleInc/loops-and-logic#3 (actually in Tangible Blocks)

---

It needs to handle:

- When fields are registered late, after `admin_enqueue_scripts` action has run already
- When fields are used on the frontend where `admin_enqueue_scripts` is never called
